### PR TITLE
add support for project sub-tasks

### DIFF
--- a/tt.sh
+++ b/tt.sh
@@ -36,19 +36,16 @@ function time_in {
 		activity="${@:2}"
 	fi
 	#
-	# Split the activity into
-	#   - the project: anything before
-	#       - the first [[:blank:]]: OR
-	#       - the first :[[:blank:]] OR
-	#       - the first [[:blank:]]s
-	#     colon-separated project hierarchy is supported
-	#     in the absence of colon, whitespace-containing project names
-	#     aren't supported.
+	# Split the activity into:
+	#
+	#   - the project: anything before the first whitespace(s)
+	#     whitespace-containing project name aren't supported.
 	#     (maps to the hledger transaction virtual account)
-	#   - the project task: anything after the project
+	#
+	#   - the project task: anything following the first whitespace(s)
 	#     (maps to the hledger transaction description)
 	#
-	local project_task=$(echo "${activity}" | sed -E "s/[[:blank:]]:|:[[:blank:]]|[[:blank:]]+/  /")
+	local project_task=$(echo "${activity}" | sed -E "s/[[:blank:]]+/  /")
 	echo "Begin ${project_task} at ${time}"
 	echo "i ${time} ${project_task}" >> $TIME_FILE
 }


### PR DESCRIPTION
This PR enables keeping track of a description of a sub-task when working on projects

```bash
$ tt i personal:projecta taska1
Begin personal:projecta  taska1 at 2019-09-10 13:26:30
$ sleep 60
$ tt o
End at 2019-09-10 13:27:45
$ tt i personal:projecta taska2
Begin personal:projecta  taska2 at 2019-09-10 13:27:52
$ sleep 60
$ tt o
End at 2019-09-10 13:28:58
$ tt i personal:projectb taskb1 && sleep 61 && tt o
Begin personal:projectb  taskb1 at 2019-09-10 13:29:15
End at 2019-09-10 13:30:16
$ tt i personal:projectb taskb2 && sleep 61 && tt o
Begin personal:projectb  taskb2 at 2019-09-10 13:31:06
End at 2019-09-10 13:32:07
$ tt i work:projectc taskc1 && sleep 61 && tt o
Begin work:projectc  taskc1 at 2019-09-10 13:32:17
End at 2019-09-10 13:33:18
$ tt i work:projectc taskc2 && sleep 61 && tt o
Begin work:projectc  taskc2 at 2019-09-10 13:33:23
End at 2019-09-10 13:34:24


$ tt b
               0.07h  personal
               0.04h    projecta
               0.03h    projectb
               0.03h  work:projectc
--------------------
               0.11h

$ hledger print -f ~/.hours.timeclock 
2019/09/10 * taska1
    (personal:projecta)           0.02h

2019/09/10 * taska2
    (personal:projecta)           0.02h

2019/09/10 * taskb1
    (personal:projectb)           0.02h

2019/09/10 * taskb2
    (personal:projectb)           0.02h

2019/09/10 * taskc1
    (work:projectc)           0.02h

2019/09/10 * taskc2
    (work:projectc)           0.02h

```